### PR TITLE
Invalidate meta cache for ICOS Cities

### DIFF
--- a/jvm/src/main/scala/se/lu/nateko/cp/doi/DoiClientRouting.scala
+++ b/jvm/src/main/scala/se/lu/nateko/cp/doi/DoiClientRouting.scala
@@ -15,6 +15,7 @@ import scala.concurrent.duration.DurationInt
 import akka.NotUsed
 import scala.util.control.NoStackTrace
 import java.util.concurrent.ExecutionException
+import java.net.URI
 
 class DoiClientRouting(client: DoiClient, conf: DoiConfig)(using ActorSystem) {
 	import DoiClientRouting._
@@ -41,14 +42,22 @@ class DoiClientRouting(client: DoiClient, conf: DoiConfig)(using ActorSystem) {
 
 							import meta.doi.{prefix, suffix}
 
+							val metaHost = meta.url.fold(conf.metaHost)(url => {
+								val targetHost = new URI(url).getHost()
+								if (targetHost.endsWith("icos-cp.eu"))
+									targetHost
+								else
+									conf.metaHost
+							})
+
 							def cacheInvalidationError(exc: Throwable): String = exc match
 								case ee: ExecutionException => cacheInvalidationError(ee.getCause)
 								case exc: Throwable =>
-									s"Cache invalidation for DOI citation on server ${conf.metaHost} for DOI $prefix/$suffix failed\n" +
+									s"Cache invalidation for DOI citation on server ${metaHost} for DOI $prefix/$suffix failed\n" +
 										s"Error message: ${exc.getMessage}"
 
 							val cacheInvalidationDone: Future[NotUsed] = Http().singleRequest(
-									HttpRequest(uri = s"https://${conf.metaHost}/dois/dropCache/$prefix/$suffix", method = HttpMethods.POST)
+									HttpRequest(uri = s"https://${metaHost}/dois/dropCache/$prefix/$suffix", method = HttpMethods.POST)
 								).flatMap{resp =>
 									if(resp.status.isSuccess) Future.successful(NotUsed)
 									else resp.entity.toStrict(3.seconds).flatMap{entity =>


### PR DESCRIPTION
Choose meta host for cache invalidation based on the target URL if the URL ends with `icos-cp.eu`. Defaults to `meta.icos-cp.eu`.