### PR TITLE
fix rights widget not updating

### DIFF
--- a/js/src/main/scala/se/lu/nateko/cp/doi/gui/widgets/RightsWidget.scala
+++ b/js/src/main/scala/se/lu/nateko/cp/doi/gui/widgets/RightsWidget.scala
@@ -21,6 +21,18 @@ class RightsWidget(init: Rights, protected val updateCb: Rights => Unit) extends
 		rightsIdentifier.element.value = "CC-BY-4.0"
 		rightsIdentifierScheme.element.value = "SPDX"
 		lang.element.value = "eng"
+		statementInput.validate()
+		urlInput.validate()
+		rightsIdentifier.validate()
+		_rights = _rights.copy(
+			statementInput.element.value,
+			Some(urlInput.element.value),
+			Some(schemeUri.element.value),
+			Some(rightsIdentifier.element.value),
+			Some(rightsIdentifierScheme.element.value),
+			Some(lang.element.value)
+		)
+		updateCb(_rights)
 	}
 
 	private[this] val ccZeroButton = button(

--- a/js/src/main/scala/se/lu/nateko/cp/doi/gui/widgets/RightsWidget.scala
+++ b/js/src/main/scala/se/lu/nateko/cp/doi/gui/widgets/RightsWidget.scala
@@ -48,6 +48,18 @@ class RightsWidget(init: Rights, protected val updateCb: Rights => Unit) extends
 		rightsIdentifier.element.value = "CC0-1.0"
 		rightsIdentifierScheme.element.value = "SPDX"
 		lang.element.value = "eng"
+		statementInput.validate()
+		urlInput.validate()
+		rightsIdentifier.validate()
+		_rights = _rights.copy(
+			statementInput.element.value,
+			Some(urlInput.element.value),
+			Some(schemeUri.element.value),
+			Some(rightsIdentifier.element.value),
+			Some(rightsIdentifierScheme.element.value),
+			Some(lang.element.value)
+		)
+		updateCb(_rights)
 	}
 
 	private[this] val statementInput = new TextInputWidget(init.rights, rs => {


### PR DESCRIPTION
After updating rights properties, there was an issue where the textbox validation in the frontend wouldn't update when using the autofill buttons unless each textbox was then explicitly updated. This has now been fixed and the only thing that is required for the frontend validation to pass is to click one of the autofill buttons.