### PR TITLE
Manage javascript and css assets cache

### DIFF
--- a/jvm/src/main/scala/se/lu/nateko/cp/doi/AssetHash.scala
+++ b/jvm/src/main/scala/se/lu/nateko/cp/doi/AssetHash.scala
@@ -1,0 +1,31 @@
+package se.lu.nateko.cp.doi
+
+import java.security.MessageDigest
+import scala.util.Using
+
+object AssetHash {
+
+	private val hashes = collection.concurrent.TrieMap.empty[String, String]
+
+	def jsFileName(isDevelopment: Boolean): String =
+		if isDevelopment then "doi-js-fastopt.js"
+		else s"doi.${forResource("doi-js-opt.js")}.js"
+
+	def cssFileName(isDevelopment: Boolean): String =
+		if isDevelopment then "styles.css"
+		else s"styles.${forResource("styles.css")}.css"
+
+	def forResource(resourceName: String): String =
+		hashes.getOrElseUpdate(resourceName, computeHash(resourceName))
+
+	private def computeHash(resourceName: String): String =
+		val stream = getClass.getClassLoader.getResourceAsStream(resourceName)
+		if stream == null then sys.error(s"Resource not found: $resourceName")
+		Using.resource(stream){is =>
+			MessageDigest.getInstance("SHA-256")
+				.digest(is.readAllBytes())
+				.take(12)
+				.map(b => f"${b & 0xff}%02x")
+				.mkString
+		}
+}

--- a/jvm/src/main/scala/se/lu/nateko/cp/doi/Main.scala
+++ b/jvm/src/main/scala/se/lu/nateko/cp/doi/Main.scala
@@ -3,6 +3,7 @@ package se.lu.nateko.cp.doi
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{`Cache-Control`, CacheDirectives}
 import akka.http.scaladsl.marshalling.ToResponseMarshaller
 import akka.http.scaladsl.server.Directives._
 import akka.stream.Materializer
@@ -31,6 +32,10 @@ object Main{
 		import system.dispatcher
 
 		val conf = DoiConfig.getConfig
+
+		if !conf.development then
+			AssetHash.jsFileName(false)
+			AssetHash.cssFileName(false)
 
 		val authRouting = new AuthRouting(conf.auth)
 
@@ -72,6 +77,12 @@ object Main{
 				views.html.doi.DoiSubmissionEmail(uid, doi).body
 			)
 		)(using ExecutionContext.Implicits.global)
+
+		def noStoreResource(resourceName: String) = respondWithHeader(
+			`Cache-Control`(CacheDirectives.`no-store`)
+		){
+			getFromResource(resourceName)
+		}
 
 		val route = handleExceptions(exceptionHandler){
 			pathPrefix("api"){
@@ -129,7 +140,21 @@ object Main{
 						complete(StatusCodes.OK)
 					}
 				} ~
-				getFromResourceDirectory("") ~
+				path("doi-js-fastopt.js"){
+					noStoreResource("doi-js-fastopt.js")
+				} ~
+				path("doi-js-fastopt.js.map"){
+					noStoreResource("doi-js-fastopt.js.map")
+				} ~
+				path("styles.css"){
+					noStoreResource("styles.css")
+				} ~
+				path("doi\\.[0-9a-f]+\\.js".r){ _ =>
+					getFromResource("doi-js-opt.js")
+				} ~
+				path("styles\\.[0-9a-f]+\\.css".r){ _ =>
+					getFromResource("styles.css")
+				} ~
 				// SPA catch-all - serve index for any /doi/* path
 				pathPrefix("doi"){
 					path(DoiClientRouting.DoiPath){doi =>

--- a/jvm/src/main/twirl/views/doi/DoiPage.scala.html
+++ b/jvm/src/main/twirl/views/doi/DoiPage.scala.html
@@ -1,9 +1,10 @@
 @import views.html.CpCommonPage
 @import eu.icoscp.envri.Envri
+@import se.lu.nateko.cp.doi.AssetHash
 
 @(isLoggedIn: Boolean, isAdmin: Boolean, isDevelopment: Boolean = false, authHost: String, doiSuffix: Option[String] = None)(implicit env: Envri)
 @CpCommonPage(s"${devIcon}${pageTitle}"){
-	<link rel="stylesheet" type="text/css" href="/styles.css">
+	<link rel="stylesheet" type="text/css" href="/@AssetHash.cssFileName(isDevelopment)">
 }{
 	<div id="main-wrapper" class="container-xxl @isAdminClass @isLoggedInClass" data-development="@isDevelopment" data-envri="@env.shortName">
 		<div class="row">
@@ -28,7 +29,7 @@
 	</div>
 
 
-	<script src="/doi-js-@{if(isDevelopment) "fast" else ""}opt.js"></script>
+	<script src="/@AssetHash.jsFileName(isDevelopment)"></script>
 	<script>
 		document.addEventListener("DOMContentLoaded", function() {
 			var loginLink = document.getElementById("login-link");


### PR DESCRIPTION
We haven't explicitly managed JavaScript and CSS assets caching behavior until now. This prevents them from getting updated directly after we change them. 

With this change, we would have a clear strategy where:
- In development, nothing gets cached. This can be tested locally with `development = true` in `application.conf`.
- In staging/production, JavaScript and CSS assets get a hash in their filename and cached indefinitely. When assets are modified and get a new hash, browser will directly download the new files. This can be tested on https://doistaging.icos-cp.eu/. The nginx configuration changes can be found at https://github.com/ICOS-Carbon-Portal/infrastructure/pull/97.