### PR TITLE
Improve layout consistency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val doi = crossProject(JSPlatform, JVMPlatform)
 			"com.typesafe.akka" %% "akka-slf4j"           % "2.6.19" cross CrossVersion.for3Use2_13,
 			"ch.qos.logback"     % "logback-classic"      % "1.1.3",
 			"com.sun.mail"       % "jakarta.mail"         % "1.6.7",
-			"se.lu.nateko.cp"   %% "views-core"           % "0.8.5",
+			"se.lu.nateko.cp"   %% "views-core"           % "0.8.6",
 			"se.lu.nateko.cp"   %% "cpauth-core"          % "0.10.1",
 		),
 		reStart / baseDirectory  := {

--- a/js/src/main/scala/se/lu/nateko/cp/doi/gui/widgets/generic/MultiEntitiesEditWidget.scala
+++ b/js/src/main/scala/se/lu/nateko/cp/doi/gui/widgets/generic/MultiEntitiesEditWidget.scala
@@ -83,7 +83,7 @@ abstract class MultiEntitiesEditWidget[E, W <: EntityWidget[E]](
 	private val addWidgetButton = button(
 			tpe := "button", cls := "btn btn-sm " + buttonType,
 			htmlTitle := "Add another item to the list",
-			onclick := addWidget, marginBottom := 5
+			onclick := addWidget
 		)(
 			span(cls := addIcon + " me-1"),
 			"Add " + title.dropRight(1).toLowerCase

--- a/js/src/main/scala/se/lu/nateko/cp/doi/gui/widgets/generic/RemovableEntityWidget.scala
+++ b/js/src/main/scala/se/lu/nateko/cp/doi/gui/widgets/generic/RemovableEntityWidget.scala
@@ -19,8 +19,10 @@ class RemovableEntityWidget[E](
 		updateCb(e)
 	})
 
+	private[this] val actionButtonClasses = "btn btn-sm btn-link entity-action-btn"
+
 	private[this] val removeButton =
-		button(tpe := "button", cls := "btn btn-sm btn-link m-1")(
+		button(tpe := "button", cls := actionButtonClasses)(
 			span(cls := "fas fa-trash")
 		).render
 
@@ -35,12 +37,12 @@ class RemovableEntityWidget[E](
 	}
 
 	private[this] val moveUpButton =
-		button(tpe := "button", cls := "btn btn-sm btn-link m-1")(
+		button(tpe := "button", cls := actionButtonClasses)(
 			span(cls := "fas fa-arrow-up")
 		).render
 
 	private[this] val moveDownButton =
-		button(tpe := "button", cls := "btn btn-sm btn-link m-1")(
+		button(tpe := "button", cls := actionButtonClasses)(
 			span(cls := "fas fa-arrow-down")
 		).render
 
@@ -57,7 +59,9 @@ class RemovableEntityWidget[E](
 	val element =
 		div(cls := "row row-cols-auto")(
 			div(cls := "col-md")(widget.element),
-			div(cls := "col-xl-2 col-lg-3 text-end", style := "min-width: 120px;")(div(moveUpButton, moveDownButton, removeButton))
+			div(cls := "col-xl-2 col-lg-3 text-end", style := "min-width: 120px;")(
+				div(cls := "entity-action-buttons")(moveUpButton, moveDownButton, removeButton)
+			)
 		)
 	.render
 }

--- a/jvm/src/main/resources/styles.css
+++ b/jvm/src/main/resources/styles.css
@@ -1,3 +1,28 @@
+#main-wrapper .btn,
+#main-wrapper .form-control,
+#main-wrapper .form-select,
+#main-wrapper .input-group-text,
+#main-wrapper .dropdown-menu {
+	font-size: 14px;
+}
+
+#main-wrapper .dropdown-menu {
+	--bs-dropdown-font-size: 14px;
+}
+
+#navbar-main #cp_theme_d10_menu,
+#navbar-main #cp_theme_d10_menu .dropdown-menu {
+	font-size: 15px;
+}
+
+#cp-header a,
+#cp-header .header-link,
+#cp-header .cart-link.fs-sm,
+#cp-header .account-link.fs-sm,
+#cp-header .login-link.fs-sm {
+	font-size: 14px;
+}
+
 /* Hide content initially if on detail route to prevent flash */
 #main-wrapper {
 	opacity: 0;
@@ -27,6 +52,14 @@ html, body {
 }
 .row .row + .row {
 	margin-top: 0.5rem;
+}
+.entity-action-buttons {
+	white-space: nowrap;
+}
+.entity-action-btn {
+	margin: 0;
+	padding-right: 0.5rem;
+	padding-left: 0.5rem;
 }
 span.label{
 	font-size: 100%;

--- a/jvm/src/main/resources/styles.css
+++ b/jvm/src/main/resources/styles.css
@@ -2,7 +2,8 @@
 #main-wrapper .form-control,
 #main-wrapper .form-select,
 #main-wrapper .input-group-text,
-#main-wrapper .dropdown-menu {
+#main-wrapper .dropdown-menu,
+#main-wrapper .page-link {
 	font-size: 14px;
 }
 

--- a/jvm/src/main/resources/styles.css
+++ b/jvm/src/main/resources/styles.css
@@ -1,29 +1,3 @@
-#main-wrapper .btn,
-#main-wrapper .form-control,
-#main-wrapper .form-select,
-#main-wrapper .input-group-text,
-#main-wrapper .dropdown-menu,
-#main-wrapper .page-link {
-	font-size: 14px;
-}
-
-#main-wrapper .dropdown-menu {
-	--bs-dropdown-font-size: 14px;
-}
-
-#navbar-main #cp_theme_d10_menu,
-#navbar-main #cp_theme_d10_menu .dropdown-menu {
-	font-size: 15px;
-}
-
-#cp-header a,
-#cp-header .header-link,
-#cp-header .cart-link.fs-sm,
-#cp-header .account-link.fs-sm,
-#cp-header .login-link.fs-sm {
-	font-size: 14px;
-}
-
 /* Hide content initially if on detail route to prevent flash */
 #main-wrapper {
 	opacity: 0;

--- a/jvm/src/main/resources/styles.css
+++ b/jvm/src/main/resources/styles.css
@@ -134,8 +134,6 @@ span.label{
 	padding: 0.4rem 0.5rem;
 }
 
-.doi-editor-with-sidebar .toc-sidebar-editor .toc-body {
-}
 
 .doi-editor-with-sidebar .toc-sidebar-editor .toc-link {
 	display: block;


### PR DESCRIPTION
The alignment and size of some elements became wrong following the redesign and root font size increase from 14 to 16px. Most bootstrap elements use `rem` units and were not matching the main content element being set to 14px.

The fixes are visible at https://doistaging.icos-cp.eu/.